### PR TITLE
Added dnsutils for Shell Injection support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Preparation
 RUN rm -fr /app/* && \
-  apt-get update && apt-get install -yqq wget unzip php5-curl && \
+  apt-get update && apt-get install -yqq wget unzip php5-curl dnsutils && \
   rm -rf /var/lib/apt/lists/*
 
 # Deploy Mutillidae


### PR DESCRIPTION
In the base install, the `/index.php?page=dns-lookup.php` exercise page is not enabled because the `dig` binary is not included. I've added the dnsutils package to the Dockerfile in order to enable it.